### PR TITLE
feat: Update chat demo with new images and message types

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -40,6 +40,7 @@ import { CreatePollModal } from "@/components/chat/CreatePollModal"
 import { Poll } from "@/components/chat/Poll"
 import { CallModal } from "@/components/chat/CallModal"
 import { WebRTCManager } from "@/utils/WebRTCManager"
+import { VoiceMessage } from "@/components/chat/VoiceMessage"
 
 declare global {
   interface Window {
@@ -108,6 +109,8 @@ interface Message {
     file_name: string
     file_type: string
     file_size: number
+    url?: string
+    duration?: string
   }
 }
 
@@ -987,8 +990,45 @@ export default function ChatPage() {
                         options={message.poll.options}
                         onVote={(optionId) => handleVote(message.poll!.id, optionId)}
                       />
-                    );
+                    )
                   }
+
+                  if (message.file) {
+                    const isOwn = message.sender === localStorage.getItem("fortify_username")
+                    if (message.file.file_type.startsWith("image/")) {
+                      return (
+                        <div key={message.id} className={`flex items-start gap-2 mb-4 relative ${isOwn ? "flex-row-reverse" : "flex-row"}`}>
+                           <img
+                            src={message.sender_profile_picture}
+                            alt={message.sender}
+                            className="w-8 h-8 rounded-full"
+                          />
+                          <div className={`max-w-[70%] rounded-lg p-3 relative ${ isOwn ? "bg-purple-600" : "bg-[#2D2A3D]" }`}>
+                            {!isOwn && (<div className="text-sm font-medium mb-1 text-purple-300">{message.sender}</div>)}
+                            <img src={message.file.url} alt={message.file.file_name} className="rounded-lg max-w-xs" />
+                            {message.content && <div className="mt-2">{message.content}</div>}
+                          </div>
+                        </div>
+                      )
+                    }
+                    if (message.file.file_type.startsWith("audio/")) {
+                       return (
+                        <div key={message.id} className={`flex items-start gap-2 mb-4 relative ${isOwn ? "flex-row-reverse" : "flex-row"}`}>
+                           <img
+                            src={message.sender_profile_picture}
+                            alt={message.sender}
+                            className="w-8 h-8 rounded-full"
+                          />
+                          <div className={`max-w-[70%] rounded-lg p-3 relative ${ isOwn ? "bg-purple-600 text-white" : "bg-[#2D2A3D] text-white" }`}>
+                             {!isOwn && (<div className="text-sm font-medium mb-1 text-purple-300">{message.sender}</div>)}
+                             <VoiceMessage duration={message.file.duration!} />
+                          </div>
+                        </div>
+                      )
+                    }
+                  }
+
+
                   return (
                     <MessageBubble
                       key={message.id}
@@ -1007,7 +1047,7 @@ export default function ChatPage() {
                       onReact={(emoji) => handleReact(message.id, emoji)}
                       onPin={() => handlePinMessage(message.id)}
                     />
-                  );
+                  )
                 })}
                 <div ref={messagesEndRef} />
               </div>

--- a/components/chat/VoiceMessage.tsx
+++ b/components/chat/VoiceMessage.tsx
@@ -1,0 +1,24 @@
+import { Play } from 'lucide-react';
+
+interface VoiceMessageProps {
+  duration: string;
+}
+
+export function VoiceMessage({ duration }: VoiceMessageProps) {
+  return (
+    <div className="flex items-center space-x-2">
+      <button className="p-2 bg-purple-500 rounded-full text-white hover:bg-purple-600">
+        <Play className="w-5 h-5" />
+      </button>
+      <div className="flex items-center space-x-1 h-6">
+        <div className="w-1 h-4 bg-gray-400 rounded-full"></div>
+        <div className="w-1 h-6 bg-gray-300 rounded-full"></div>
+        <div className="w-1 h-5 bg-gray-400 rounded-full"></div>
+        <div className="w-1 h-3 bg-gray-500 rounded-full"></div>
+        <div className="w-1 h-6 bg-gray-300 rounded-full"></div>
+        <div className="w-1 h-4 bg-gray-400 rounded-full"></div>
+      </div>
+      <span className="text-sm text-gray-300">{duration}</span>
+    </div>
+  );
+}

--- a/utils/mockData.ts
+++ b/utils/mockData.ts
@@ -11,7 +11,7 @@ const mockUsers: ChatParticipant[] = [
     id: 1,
     username: 'You',
     email: 'you@test.com',
-    profile_picture: 'https://i.pravatar.cc/150?u=you',
+    profile_picture: 'https://avatar.iran.liara.run/public/26',
     is_online: true,
     last_seen: new Date().toISOString(),
   },
@@ -19,7 +19,7 @@ const mockUsers: ChatParticipant[] = [
     id: 2,
     username: 'Alice',
     email: 'alice@test.com',
-    profile_picture: 'https://i.pravatar.cc/150?u=alice',
+    profile_picture: 'https://avatar.iran.liara.run/public/86',
     is_online: true,
     last_seen: new Date().toISOString(),
   },
@@ -27,7 +27,7 @@ const mockUsers: ChatParticipant[] = [
     id: 3,
     username: 'Bob',
     email: 'bob@test.com',
-    profile_picture: 'https://i.pravatar.cc/150?u=bob',
+    profile_picture: 'https://avatar.iran.liara.run/public/32',
     is_online: false,
     last_seen: new Date(Date.now() - 86400000 * 2).toISOString(), // 2 days ago
   },
@@ -35,7 +35,7 @@ const mockUsers: ChatParticipant[] = [
     id: 4,
     username: 'Charlie',
     email: 'charlie@test.com',
-    profile_picture: 'https://i.pravatar.cc/150?u=charlie',
+    profile_picture: 'https://avatar.iran.liara.run/public/4',
     is_online: true,
     last_seen: new Date().toISOString(),
   },
@@ -43,7 +43,7 @@ const mockUsers: ChatParticipant[] = [
     id: 5,
     username: 'Diana',
     email: 'diana@test.com',
-    profile_picture: 'https://i.pravatar.cc/150?u=diana',
+    profile_picture: 'https://avatar.iran.liara.run/public/77',
     is_online: false,
     last_seen: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
   },
@@ -51,7 +51,7 @@ const mockUsers: ChatParticipant[] = [
     id: 6,
     username: 'Ethan',
     email: 'ethan@test.com',
-    profile_picture: 'https://i.pravatar.cc/150?u=ethan',
+    profile_picture: 'https://avatar.iran.liara.run/public/26',
     is_online: true,
     last_seen: new Date().toISOString(),
   }
@@ -67,7 +67,7 @@ export const mockMyProfile: UserProfile = {
       email: 'you@test.com',
       is_online: true,
       last_seen: new Date().toISOString(),
-      profile_picture: 'https://i.pravatar.cc/150?u=you',
+      profile_picture: 'https://avatar.iran.liara.run/public/26',
       bio: 'This is my awesome profile bio for the demo mode!',
     },
     date_of_birth: '1990-01-01',
@@ -101,9 +101,14 @@ export const mockMessages: { [chatId: number]: any[] } = {
     createMockMessage(2, mockUsers[0], 'I am good, thanks for asking! Just working on this cool messenger app.', new Date(now.getTime() - 60000 * 9), true),
     createMockMessage(3, mockUsers[1], 'Oh wow, that sounds amazing! Can you show me a screenshot?', new Date(now.getTime() - 60000 * 8), false),
     createMockMessage(4, mockUsers[0], 'Sure, here is one!', new Date(now.getTime() - 60000 * 7), true, {
-      file: { file_name: 'screenshot.jpg', file_type: 'image/jpeg', file_size: 123456 }
+      file: { file_name: 'screenshot.jpg', file_type: 'image/jpeg', file_size: 123456, url: 'https://cdn11.bigcommerce.com/s-tvu0xuc8/images/stencil/1280x1280/products/6723/27443/Boy_Scout_Purple_Rhino_Patrol_Patch_-_B57671__73955.1711481876.png?c=2' }
     }),
     createMockMessage(5, mockUsers[1], 'Looks fantastic! The UI is so clean.', new Date(now.getTime() - 60000 * 6), false),
+    createMockMessage(6, mockUsers[0], 'I also implemented voice messages. Check it out.', new Date(now.getTime() - 60000 * 5), true),
+    createMockMessage(7, mockUsers[0], '', new Date(now.getTime() - 60000 * 4), true, {
+      file: { file_name: 'voice_message.ogg', file_type: 'audio/ogg', file_size: 23456, duration: '0:12' }
+    }),
+    createMockMessage(8, mockUsers[1], 'That is so cool!', new Date(now.getTime() - 60000 * 3), false),
   ],
   102: [ // Chat with Bob
     createMockMessage(1, mockUsers[2], 'Can you send me the report?', new Date(now.getTime() - 86400000), false),


### PR DESCRIPTION
This commit updates the chat demonstration to provide a more realistic and feature-rich user experience.

The following changes were made:
- Replaced the placeholder profile pictures for mock users with new, more appropriate avatars.
- Added mock messages to demonstrate sending an image and a voice note in the chat.
- Created a new `VoiceMessage` component to render a visual representation of a voice message.
- Updated the chat page to correctly render image and voice messages based on the message type.